### PR TITLE
Add extern "C" declaration

### DIFF
--- a/levenshtein.h
+++ b/levenshtein.h
@@ -10,8 +10,15 @@
  * See http://en.wikipedia.org/wiki/Levenshtein_distance
  * for more information.
  */
-
+#ifdef __cplusplus
+extern "C" {
+#endif
+  
 unsigned int
 levenshtein(const char *a, const char *b);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // LEVENSHTEIN_H


### PR DESCRIPTION
`extern "C"` is required if this is to be linked into C++ code due to the name mangling that happens with C++. Forgot to include this in my last pull request.