### PR TITLE
Add `stddef.h` for `size_t`

### DIFF
--- a/levenshtein.h
+++ b/levenshtein.h
@@ -1,6 +1,8 @@
 #ifndef LEVENSHTEIN_H
 #define LEVENSHTEIN_H
 
+#include <stddef.h>
+
 // `levenshtein.h` - levenshtein
 // MIT licensed.
 // Copyright (c) 2015 Titus Wormer <tituswormer@gmail.com>


### PR DESCRIPTION
Without this include:

    $ cat main.c
    #include "levenshtein.h"

    int main(void)
    {
	    return 0;
    }
    $ gcc main.c
    In file included from main.c:1:
    levenshtein.h:16:1: error: unknown type name ‘size_t’
       16 | size_t
	  | ^~~~~~
    levenshtein.h:1:1: note: ‘size_t’ is defined in header ‘<stddef.h>’; did
    you forget to ‘#include <stddef.h>’?
      +++ |+#include <stddef.h>
	1 | #ifndef LEVENSHTEIN_H
    levenshtein.h:19:1: error: unknown type name ‘size_t’
       19 | size_t
	  | ^~~~~~
    levenshtein.h:19:1: note: ‘size_t’ is defined in header ‘<stddef.h>’;
    did you forget to ‘#include <stddef.h>’?
    levenshtein.h:20:37: error: unknown type name ‘size_t’
       20 | levenshtein_n (const char *a, const size_t length, const char
    *b, const size_t bLength);
	  |                                     ^~~~~~
    levenshtein.h:20:73: error: unknown type name ‘size_t’
       20 | levenshtein_n (const char *a, const size_t length, const char
    *b, const size_t bLength);
	  |
    ^~~~~~